### PR TITLE
Add redirect handler

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -13,7 +13,6 @@ const sitePath = new URLSearchParams(window.location.search).get('site_path');
 const redirects = ${JSON.stringify(REDIRECTS)};
 if (sitePath && redirects[sitePath]) {
   window.location.replace(redirects[sitePath]);
-  document.pause();
 }
 `
 


### PR DESCRIPTION
## Context


8thwall.com is redirecting to 8thwall.org. When there is a path specified, such as https://www.8thwall.com/tutorials, we end up on https://8thwall.org/?site_path=tutorials.

Optimally this logic would be server side, but since github pages is static, it needs to be in javascript.

Rather than using an effect, which would be mounted much later in the page load process, injecting the script tag inline in the head gives the fastest redirect logic we can muster.

This is the first of possibly many redirects we may want to add. This URL specifically is in the sidebar of the desktop app.

## Testing

`npm start`

- Everything is normal without a site_path 
- http://localhost:3000/?site_path=tutorials redirects
- http://localhost:3000/downloads?site_path=tutorials does not redirect

Same behavior on production builds with:

```
npm run build && npm run serve
```