### PR TITLE
Update navigation links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,12 +65,12 @@ const config = {
         style: { height: '24px', width: 'auto' },
       },
       items: [
-        { href: 'https://github.com/8thwall', label: 'GitHub', position: 'left' },
+        { href: 'https://github.com/8thwall/8thwall', label: 'GitHub', position: 'left' },
         { href: 'https://8th.io/examples', label: 'Samples', position: 'left' },
         { href: 'https://www.youtube.com/@8thwall', label: 'Tutorials', position: 'left' },
         { to: '/blog', label: 'Blog', position: 'left' },
         { href: 'https://8th.io/discord', label: 'Discord', position: 'left' },
-        { href: 'https://www.8thwall.com/docs', label: 'Docs', position: 'left' },
+        { to: '/docs', label: 'Docs', position: 'left' },
         {
           type: 'html',
           position: 'right',

--- a/menu.mdx
+++ b/menu.mdx
@@ -98,7 +98,7 @@ description: 8th Wall Documentation
     <div className="resources-section">
       <h2 className="resources-title">Additional Resources</h2>
       <div className="resources-grid">
-        <a href="https://github.com/8thwall" target="_blank" className="resource-card">
+        <a href="https://github.com/8thwall/8thwall" target="_blank" className="resource-card">
           <div className="resource-icon">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-github" viewBox="0 0 16 16">
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"/>

--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -24,7 +24,7 @@ export default function SiteFooter() {
               <h2 className="footer-heading">Resources</h2>
               <a href="https://8th.io/migration" target="_blank" rel="noopener">Documentation</a>
               <a href="https://www.youtube.com/@8thwall" target="_blank" rel="noopener">Video Tutorials</a>
-              <a href="https://github.com/8thwall" target="_blank" rel="noopener">GitHub</a>
+              <a href="https://github.com/8thwall/8thwall" target="_blank" rel="noopener">GitHub</a>
               <a href="https://8th.io/examples" target="_blank" rel="noopener">Example Projects</a>
               <Link to="/blog">Blog</Link>
             </div>

--- a/src/components/SiteNav.jsx
+++ b/src/components/SiteNav.jsx
@@ -34,8 +34,8 @@ export default function SiteNav() {
 
   const navLinks = (
     <>
-      <a href="https://github.com/8thwall" target="_blank" rel="noopener">GitHub</a>
-      <a href="https://8thwall.com/docs/" target="_blank" rel="noopener">Docs</a>
+      <a href="https://github.com/8thwall/8thwall" target="_blank" rel="noopener">GitHub</a>
+      <Link to="/docs">Docs</Link>
       <a href="https://8th.io/examples" target="_blank" rel="noopener">Samples</a>
       <a href="https://www.youtube.com/@8thwall" target="_blank" rel="noopener">Tutorials</a>
       <Link to="/blog">Blog</Link>


### PR DESCRIPTION
## Context

Linking directly to the main repo probably makes things easier to find what people are looking for.

Switching to 8thwall.org docs for primary docs.

## Testing


<img width="697" height="169" alt="Screenshot 2026-03-27 at 10 42 28 AM" src="https://github.com/user-attachments/assets/f9aa3dd5-30d1-4899-a1c1-2cf7ccef9d3b" />


- Main nav looks ok
- Mobile sidebar looks ok
