### PR TITLE
Add data requests page to legacy policies

### DIFF
--- a/legacy-policies/data-requests.md
+++ b/legacy-policies/data-requests.md
@@ -11,7 +11,7 @@ The 8th Wall hosted platform was retired on **February 28, 2026**. Self-service 
 
 ## Recover Your Project Data
 
-To request an export of your project files, email [privacy@nianticspatial.com](mailto:privacy@nianticspatial.com) with the subject line **"8th Wall Data Recovery Request"** and include:
+To request an export of your project files, email [privacy@nianticspatial.com](mailto:privacy@nianticspatial.com?subject=8th%20Wall%20Data%20Recovery%20Request&body=Account%20email%3A%20%0AProject%20name(s)%3A%20%0ARequest%20type%3A%20Data%20Recovery) with the subject line **"8th Wall Data Recovery Request"** and include:
 
 - The email address associated with your 8th Wall account
 - The name(s) of the project(s) you want to recover
@@ -23,7 +23,7 @@ You will receive your project files as a **.zip archive**. Allow reasonable time
 
 ## Request Erasure of Your Data
 
-To request deletion of your account data and project files, email [privacy@nianticspatial.com](mailto:privacy@nianticspatial.com) with the subject line **"8th Wall Data Erasure Request"** and include:
+To request deletion of your account data and project files, email [privacy@nianticspatial.com](mailto:privacy@nianticspatial.com?subject=8th%20Wall%20Data%20Erasure%20Request&body=Account%20email%3A%20%0AProject%20name(s)%3A%20%0ARequest%20type%3A%20Data%20Erasure) with the subject line **"8th Wall Data Erasure Request"** and include:
 
 - The email address associated with your 8th Wall account
 - The name(s) of any specific project(s) you want deleted, or indicate that you want all data removed


### PR DESCRIPTION
## Summary

- Adds `/legacy-policies/data-requests` page explaining that self-service export is no longer available following the Feb 28, 2026 platform shutdown
- Reassures users project files are retained until Aug 31, 2027
- Provides clear CTAs for data recovery and erasure requests via `privacy@nianticspatial.com` with guidance on what to include
- Includes deadline warning that all data is permanently deleted after Aug 31, 2027
- Links to the 8th Wall Legacy Privacy Policy for full details

## Test plan

- [x] Visit `/legacy-policies/data-requests` and confirm page renders correctly
- [x] Verify mailto links open with correct subject lines
- [x] Confirm page appears in legacy policies sidebar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)