### PR TITLE
Add configuration for routing featured projects to their published domain

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -8,11 +8,24 @@ const REDIRECTS = {
   'tutorials': 'https://youtube.com/@8thwall',
 }
 
+// NOTE(christoph): If a user is linked to a featured project page such as 
+// https://8thwall.com/workspace/project, they will be redirected to 
+// 8thwall.org?site_path=workspace/project. We can then forward that to the published domain:
+// https://workspace.8thwall.app/project
+const PUBLISHED_DOMAIN_REDIRECTS = [
+  'mindoverdevelopment',
+]
+
 const REDIRECT_SCRIPT = `
 const sitePath = new URLSearchParams(window.location.search).get('site_path');
 const redirects = ${JSON.stringify(REDIRECTS)};
 if (sitePath && redirects[sitePath]) {
   window.location.replace(redirects[sitePath]);
+} else {
+  const domainRedirect = ${JSON.stringify(PUBLISHED_DOMAIN_REDIRECTS)}.find(domain => sitePath.startsWith(domain + '/'));
+  if (domainRedirect) {
+    window.location.replace('https://' + domainRedirect + '.8thwall.app/' + sitePath.substring(domainRedirect.length + 1));
+  }
 }
 `
 


### PR DESCRIPTION
## Context

A user reached out about how their links to their featured project pages are no longer accessible due to 8thwall.com shutting down and redirecting to 8thwall.org. Since we preserved the `site_path` parameter, we have the option to add routing rules to get the browser to the right place.

Waiting on confirmation from the user that this is what they would like.

## Testing

- http://localhost:3000/?site_path=mindoverdevelopment%2Ftest goes to the expected place
- http://localhost:3000/?site_path=mindoverdevelopment2%2Ftest is not affected
- http://localhost:3000/?site_path=tutorials still works
