### PR TITLE
Update downloads page to reflect current state

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1462,6 +1462,7 @@ footer.footer .footer-legal-link:hover {
 .download-option:hover {
   border-color: var(--color-primary);
   background-color: rgba(168, 85, 247, 0.05);
+  text-decoration: none;
 }
 
 .download-option-icon {

--- a/src/pages/downloads.jsx
+++ b/src/pages/downloads.jsx
@@ -33,7 +33,7 @@ export default function Downloads() {
               <div className="download-column">
                 <h3 className="download-column-title">Mac</h3>
                 <div className="download-column-buttons">
-                  <a href="https://8th.io/mac-arm64-latest" className="download-option">
+                  <a href="https://8th.io/mac-arm64-latest" className="download-option" download>
                     <div className="download-option-icon">
                       <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
@@ -48,7 +48,7 @@ export default function Downloads() {
                       <line x1="12" y1="15" x2="12" y2="3" />
                     </svg>
                   </a>
-                  <a href="https://8th.io/mac-intel-latest" className="download-option">
+                  <a href="https://8th.io/mac-intel-latest" className="download-option" download>
                     <div className="download-option-icon">
                       <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
@@ -68,7 +68,7 @@ export default function Downloads() {
               <div className="download-column">
                 <h3 className="download-column-title">Windows</h3>
                 <div className="download-column-buttons">
-                  <a href="https://8th.io/win-x64-latest" className="download-option">
+                  <a href="https://8th.io/win-x64-latest" className="download-option" download>
                     <div className="download-option-icon">
                       <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M3 12V6.75l9-5.25 9 5.25V12l-9 5.25L3 12zm9 3.75l7-4.083V7.5L12 11.583 5 7.5v4.167l7 4.083zM12 3L5.5 6.75 12 10.5l6.5-3.75L12 3z" />

--- a/src/pages/downloads.jsx
+++ b/src/pages/downloads.jsx
@@ -26,14 +26,14 @@ export default function Downloads() {
               </div>
               <div className="download-category-info">
                 <h2 className="download-category-title">8th Wall Desktop</h2>
-                <p className="download-category-description">XR Game Engine for development. Build 3D & AR experiences and deploy to web, iOS, and Android.</p>
+                <p className="download-category-description">XR Game Engine for development. Build 3D & AR experiences and deploy to web.</p>
               </div>
             </div>
             <div className="download-columns">
               <div className="download-column">
                 <h3 className="download-column-title">Mac</h3>
                 <div className="download-column-buttons">
-                  <a href="https://8th.io/mac-arm64-latest" className="download-option" target="_blank" rel="noopener">
+                  <a href="https://8th.io/mac-arm64-latest" className="download-option">
                     <div className="download-option-icon">
                       <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
@@ -48,7 +48,7 @@ export default function Downloads() {
                       <line x1="12" y1="15" x2="12" y2="3" />
                     </svg>
                   </a>
-                  <a href="https://8th.io/mac-intel-latest" className="download-option" target="_blank" rel="noopener">
+                  <a href="https://8th.io/mac-intel-latest" className="download-option">
                     <div className="download-option-icon">
                       <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
@@ -68,7 +68,7 @@ export default function Downloads() {
               <div className="download-column">
                 <h3 className="download-column-title">Windows</h3>
                 <div className="download-column-buttons">
-                  <a href="https://8th.io/win-x64-latest" className="download-option" target="_blank" rel="noopener">
+                  <a href="https://8th.io/win-x64-latest" className="download-option">
                     <div className="download-option-icon">
                       <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M3 12V6.75l9-5.25 9 5.25V12l-9 5.25L3 12zm9 3.75l7-4.083V7.5L12 11.583 5 7.5v4.167l7 4.083zM12 3L5.5 6.75 12 10.5l6.5-3.75L12 3z" />
@@ -87,7 +87,7 @@ export default function Downloads() {
                 </div>
               </div>
             </div>
-            <p className="download-note">Offline download available now. Full open source coming soon.</p>
+            <p className="download-note">Past releases can be accessed on <a href="http://github.com/8thwall/desktop/releases">Github Releases</a></p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Context

- Updated the wording to reflect that the desktop app is now open source and published through github
- The text underline while hovering a download option was a bit confusing. 
- Replaced `target="_blank"` with `download` to better indicate the intent of the link
- Removed mention of android and ios because they are not currently supported.
 
## Testing

### Before

<img width="726" height="616" alt="Screenshot 2026-04-03 at 7 34 36 AM" src="https://github.com/user-attachments/assets/8db13d61-3bec-4b1a-a10f-803cf5c1d3c2" />

### After

<img width="713" height="596" alt="Screenshot 2026-04-03 at 7 34 59 AM" src="https://github.com/user-attachments/assets/3e52a4ff-0510-4137-b0dd-5edd8421129c" />

