### PR TITLE
Show search box on 404 page

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -143,9 +143,10 @@ html.plugin-id-legacy-policies .navbar-download-btn {
   }
 }
 
-/* Hide search bar on non-docs pages */
-body .DocSearch-Button { display: none; }
-html.docs-doc-page:not(.plugin-id-legacy-policies) body .DocSearch-Button { display: flex; }
+/* Only show the search box on docs pages and not on the legacy policies section */
+html:not(.plugin-docs) .DocSearch-Button, html.plugin-id-legacy-policies .DocSearch-Button { 
+  display: none; 
+}
 
 /* DocSearch button styling */
 body .DocSearch-Button {


### PR DESCRIPTION
## Context

Closes #25 

## Testing

- Visible on docs pages: http://localhost:3000/docs/open-source
- Visible on 404 page if the prefix starts with `/docs/`: http://localhost:3000/docs/something
- Not visible on other 404 pages: http://localhost:3000/something
- Not visible on blog pages: http://localhost:3000/blog
- Not visible on legacy policies pages: http://localhost:3000/legacy-policies/dpa
- Not visible on downloads pages: http://localhost:3000/downloads