### PR TITLE
Add redirect for customer direct link

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -6,6 +6,7 @@ import HeroCanvas from '@site/src/components/HeroCanvas';
 
 const REDIRECTS = {
   'tutorials': 'https://youtube.com/@8thwall',
+  'twainxreducation/brandigno': 'https://twainxreducation.8thwall.app/brandigno/',
 }
 
 const REDIRECT_SCRIPT = `


### PR DESCRIPTION
## Context

Requested in discord https://discord.com/channels/1341900046278328383/1507044291548283051/1507044291548283051

This customer's QR code originally linked to https://www.8thwall.com/twainxreducation/brandigno since they didn't have direct URL access. Now that 8thwall.com has been commissioned, it's redirecting to https://8thwall.org/?site_path=twainxreducation%2Fbrandigno

The original page would have had a button to open https://twainxreducation.8thwall.app/brandigno/ but we can redirect directly for now. 

To catch the case of these paths in general, it might make sense to add redirect logic if there is a site_path found, and if the link structure matches this format, show a link to the experience URL.

## Testing

https://localhost:3000/?site_path=twainxreducation%2Fbrandigno redirects to the project URL