### PR TITLE
Remove trailing slashes in path

### DIFF
--- a/src/theme/DocItem/Content/index.jsx
+++ b/src/theme/DocItem/Content/index.jsx
@@ -8,7 +8,7 @@ export default function DocItemContent(props) {
     pathname.startsWith('/legacy-policies/') && pathname !== '/legacy-policies/';
 
   if (pathname.length > 1 && pathname.endsWith('/')) {
-    return <Redirect to={pathname.slice(0,-1)}/>
+    return <Redirect to={pathname.slice(0, -1)}/>
   }
 
   return (

--- a/src/theme/DocItem/Content/index.jsx
+++ b/src/theme/DocItem/Content/index.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import Content from '@theme-original/DocItem/Content';
-import { useLocation } from '@docusaurus/router';
+import { Redirect, useLocation } from '@docusaurus/router';
 
 export default function DocItemContent(props) {
   const { pathname } = useLocation();
   const isLegacyDoc =
     pathname.startsWith('/legacy-policies/') && pathname !== '/legacy-policies/';
+
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return <Redirect to={pathname.slice(0,-1)}/>
+  }
 
   return (
     <>


### PR DESCRIPTION
## Context

Noticed in our new hosting setup on github pages, links with trailing slashes are actually served as 404s:

```
curl -sI https://8thwall.org/docs
HTTP/2 200
server: GitHub.com
content-type: text/html; charset=utf-8
...

curl -sI https://8thwall.org/docs/
HTTP/2 404
server: GitHub.com
content-type: text/html; charset=utf-8
...
```

With client-side rendering, the content gets fixed if javascript is enabled, but otherwise you get the 404 page.

By removing the slashes on page load, it reduces the chance that 8thwall.org links are shared with trailing slashes

## Testing

- http://localhost:3000/ is left alone
- http://localhost:3000/docs/ is redirected to /docs
- http://localhost:3000/blog/8th-wall-open-source/ is redirected to - /blog/8th-wall-open-source